### PR TITLE
release-schema: Add LotGroup.awardCriteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Award criteria breakdown
 
-Adds an award criteria array to the lot object, to break down award criteria by price, cost and quality.
+Adds an award criteria array to the `Lot` and `LotGroup` objects, to break down award criteria by price, cost and quality.
 
 ## Legal context
 
-In the European Union, this extension's fields correspond to [eForms BG-707 (Award Criteria)](https://github.com/eForms/eForms). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
+In the European Union, this extension's fields correspond to [eForms BG-707 (Award Criteria)](https://github.com/eForms/eForms). See [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/latest/en/) for the correspondences to eForms fields. See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
 
 [Directive 2014/24/EU](https://eur-lex.europa.eu/eli/dir/2014/24/oj) [Article 67](https://eur-lex.europa.eu/eli/dir/2014/24/oj#d1e5950-65-1)(5) describes weightings and orders of importance.
 
 ## Examples
 
-### Weight
+### Lots
 
-These award criteria are 50% service quality and 50% price.
+#### Weight
+
+The award criteria for the lot are 50% service quality and 50% price.
 
 ```json
 {
@@ -50,9 +52,9 @@ These award criteria are 50% service quality and 50% price.
 }
 ```
 
-### Fixed
+#### Fixed
 
-The price is fixed at $100,000, such that tenderers compete on quality only.
+The price of the lot is fixed at $100,000, such that tenderers compete on quality only.
 
 ```json
 {
@@ -94,11 +96,45 @@ The price is fixed at $100,000, such that tenderers compete on quality only.
 }
 ```
 
+### Lot group
+
+The award criteria for the lot group is 100% price.
+
+```json
+{
+  "tender": {
+    "lotGroups": [
+      {
+        "id": "1",
+        "awardCriteria": {
+          "criteria": [
+            {
+              "type": "price",
+              "name": "Price",
+              "numbers": [
+                {
+                  "number": 100,
+                  "weight": "percentageExact"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
 ## Issues
 
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2022-02-27
+
+* Add `LotGroup.awardCriteria`.
 
 ### 2020-04-24
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -9,6 +9,15 @@
         }
       }
     },
+    "LotGroup": {
+      "properties": {
+        "awardCriteria": {
+          "title": "Award criteria",
+          "description": "Information about the award criteria for the lot.",
+          "$ref": "#/definitions/AwardCriteria"
+        }
+      }
+    },
     "AwardCriteria": {
       "title": "Award criteria",
       "description": "Information about the award criteria.",


### PR DESCRIPTION
@jpmckinney this update relates to nine different fields in eForms so, rather than listing all the fields in the readme, I added the following sentence:

> See [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/latest/en/) for the correspondences to eForms fields.

Let me know if you think it would be better to list out the fields.